### PR TITLE
Fix package : add fastentrypoint to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include versioneer.py
+include fastentrypoint.py


### PR DESCRIPTION
Hello @Konubinix ! :)

click-project package install with pip seems broken in 0.7.0:

```
$ pip install click-project==0.7.0 --no-cache
Defaulting to user installation because normal site-packages is not writeable
Collecting click-project==0.7.0
  Downloading click-project-0.7.0.tar.gz (103 kB)
     |████████████████████████████████| 103 kB 810 kB/s 
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-f83efa0n/click-project/setup.py'"'"'; __file__='"'"'/tmp/pip-install-f83efa0n/click-project/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-f83efa0n/click-project/pip-egg-info
         cwd: /tmp/pip-install-f83efa0n/click-project/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-f83efa0n/click-project/setup.py", line 6, in <module>
        import fastentrypoint  # NOQA
    ModuleNotFoundError: No module named 'fastentrypoint'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```

including fastentrypoint.py to MANIFEST.in seems to fix it.

note: not sure if symlink name 'fastentrypoint.py' without 's' is on purpose, so leaving as it is (original file is 'fastentrypoints.py' though).